### PR TITLE
fix: windows bat can't install bcs of psql not found

### DIFF
--- a/scripts/package-windows.js
+++ b/scripts/package-windows.js
@@ -172,14 +172,22 @@ echo   Windows Standalone Installer
 echo ====================================
 echo.
 
-REM Check if PostgreSQL is installed
-where psql >nul 2>nul
+REM Check for Administrator privileges
+net session >nul 2>&1
 if %ERRORLEVEL% NEQ 0 (
-    echo ⚠️  PostgreSQL not found. Please install PostgreSQL 12+ before running Chalkboard.id
-    echo    Download from: https://www.postgresql.org/download/windows/
+    echo [ERROR] Please run this installer as Administrator.
+    echo         Right-click install.bat and select "Run as administrator"
     echo.
     pause
     exit /b 1
+)
+
+REM Check if PostgreSQL is in PATH (optional - just a warning)
+where psql >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    echo [NOTE] PostgreSQL CLI not found in PATH - this is OK if you have a remote database
+    echo        or if PostgreSQL is installed but not added to PATH.
+    echo.
 )
 
 REM Create installation directory


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows installer to require Administrator privileges for installation.
  * Enhanced PostgreSQL detection to support various installation configurations, including remote or non-path-installed setups.
  * Improved installer messaging for better clarity on prerequisites and setup options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->