### PR TITLE
Fix tax calculation bug: use settings instead of hardcoded 10%

### DIFF
--- a/src/app/[locale]/(DashboardLayout)/tables/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/tables/page.tsx
@@ -30,6 +30,7 @@ import DurationManagement from "@/components/tables/DurationManagement";
 import MoveSessionModal from "@/components/tables/MoveSessionModal";
 import EnhancedBillingModal from "@/components/tables/EnhancedBillingModal";
 import { PricingPackage } from "@/schema";
+import { calculateTax as calculateTaxFromSettings, formatTaxLabel } from "@/lib/tax";
 
 // Helper function to format currency
 const formatCurrency = (amount: number | string) => {
@@ -446,7 +447,7 @@ const TablesManagement = () => {
   };
 
   const calculateTax = (subtotal: number) => {
-    return subtotal * 0.1; // 10% tax
+    return calculateTaxFromSettings(subtotal, taxSettings, false); // Use tax settings, isTable=false for F&B
   };
 
   // Process F&B Order
@@ -1501,7 +1502,7 @@ const TablesManagement = () => {
                               <span>{formatCurrency(calculateTotal())}</span>
                             </div>
                             <div className="flex justify-between">
-                              <span>Tax (10%):</span>
+                              <span>{formatTaxLabel(taxSettings)}:</span>
                               <span>{formatCurrency(calculateTax(calculateTotal()))}</span>
                             </div>
                             <div className="flex justify-between font-bold text-base border-t pt-2">


### PR DESCRIPTION
The F&B modal in the tables page was using a hardcoded 10% tax rate
instead of respecting the tax settings configured in the admin panel.
This caused tax to still be applied even when disabled or set to 0%.

Changes:
- Import calculateTax and formatTaxLabel from @/lib/tax
- Update local calculateTax function to use calculateTaxFromSettings
  with proper taxSettings state and isTable=false flag
- Replace hardcoded "Tax (10%):" label with dynamic formatTaxLabel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tax calculations now reflect current tax settings instead of using fixed rates.
  * Tax labels dynamically update to match the active tax configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->