### PR TITLE
Fix table grid positioning to use fixed order by ID

### DIFF
--- a/src/app/[locale]/(DashboardLayout)/dashboard/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/dashboard/page.tsx
@@ -95,7 +95,8 @@ const ChalkBoardDashboard = () => {
       const response = await fetch('/api/tables');
       if (response.ok) {
         const data = await response.json();
-        setTables(data);
+        const sortedTables = data.sort((a: Table, b: Table) => a.id - b.id);
+        setTables(sortedTables);
         
         // Calculate stats
         const totalTables = data.length;

--- a/src/app/[locale]/(DashboardLayout)/tables/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/tables/page.tsx
@@ -214,7 +214,8 @@ const TablesManagement = () => {
       const response = await fetch('/api/tables');
       if (response.ok) {
         const data = await response.json();
-        setTables(data);
+        const sortedTables = data.sort((a: BilliardTable, b: BilliardTable) => a.id - b.id);
+        setTables(sortedTables);
         
         // Fetch current sessions for occupied tables
         data.forEach(async (table: BilliardTable) => {

--- a/src/app/api/tables/route.ts
+++ b/src/app/api/tables/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { tables } from '@/schema/tables';
 import { pricingPackages } from '@/schema/pricing-packages';
-import { eq } from 'drizzle-orm';
+import { eq, asc } from 'drizzle-orm';
 import { auth } from '@/lib/auth';
 
 export async function GET() {
@@ -37,7 +37,8 @@ export async function GET() {
       })
       .from(tables)
       .leftJoin(pricingPackages, eq(tables.pricingPackageId, pricingPackages.id))
-      .where(eq(tables.isActive, true));
+      .where(eq(tables.isActive, true))
+      .orderBy(asc(tables.id));
     
     return NextResponse.json(allTables);
   } catch (error) {


### PR DESCRIPTION
- Add server-side sorting to /api/tables endpoint with orderBy(asc(tables.id))
- Add client-side defensive sorting to dashboard and tables management pages
- Tables now always appear in consistent positions (Table 1, Table 2, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced table data sorting to consistently display tables in ascending order by ID across all dashboard views for improved data organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->