### PR TITLE
Fix Tauri build: remove node_modules from frontendDist

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -89,22 +89,54 @@ jobs:
       - name: Build check
         run: bun run build
 
+  build-tauri-check:
+    needs: test
+    runs-on: macos-latest
+    env:
+      DEPLOYMENT_MODE: desktop
+      NEXTAUTH_SECRET: "build-time-secret-key-for-github-actions-only"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Tauri app (macOS aarch64)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --target aarch64-apple-darwin
+          uploadWorkflowArtifacts: true
+
   build-tauri:
     needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-latest
-            rust-targets: 'aarch64-apple-darwin'
           - platform: ubuntu-22.04
             rust-targets: ''
-            main-only: true
           - platform: windows-latest
             rust-targets: ''
-            main-only: true
     runs-on: ${{ matrix.platform }}
-    if: ${{ !matrix.main-only || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     env:
       DEPLOYMENT_MODE: desktop
       NEXTAUTH_SECRET: "build-time-secret-key-for-github-actions-only"
@@ -175,7 +207,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   summary:
-    needs: [test, build, build-tauri, build-docker]
+    needs: [test, build, build-tauri-check, build-tauri, build-docker]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -199,12 +231,18 @@ jobs:
 
       - name: Check Tauri build results
         run: |
-          if [[ "${{ needs.build-tauri.result }}" == "success" ]]; then
-            echo "✅ Tauri build passed"
-          elif [[ "${{ needs.build-tauri.result }}" == "skipped" ]]; then
-            echo "ℹ️ Some Tauri builds skipped (main-only platforms)"
+          if [[ "${{ needs.build-tauri-check.result }}" != "success" ]]; then
+            echo "❌ Tauri macOS aarch64 build failed"
+            exit 1
           else
-            echo "❌ Tauri build failed"
+            echo "✅ Tauri macOS aarch64 build passed"
+          fi
+          if [[ "${{ needs.build-tauri.result }}" == "success" ]]; then
+            echo "✅ Tauri platform builds passed"
+          elif [[ "${{ needs.build-tauri.result }}" == "skipped" ]]; then
+            echo "ℹ️ Tauri platform builds skipped (main-only)"
+          else
+            echo "❌ Tauri platform builds failed"
             exit 1
           fi
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -91,18 +91,20 @@ jobs:
 
   build-tauri:
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-22.04
-            rust-targets: ''
           - platform: macos-latest
             rust-targets: 'aarch64-apple-darwin'
+          - platform: ubuntu-22.04
+            rust-targets: ''
+            main-only: true
           - platform: windows-latest
             rust-targets: ''
+            main-only: true
     runs-on: ${{ matrix.platform }}
+    if: ${{ !matrix.main-only || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     env:
       DEPLOYMENT_MODE: desktop
       NEXTAUTH_SECRET: "build-time-secret-key-for-github-actions-only"
@@ -196,13 +198,14 @@ jobs:
           fi
 
       - name: Check Tauri build results
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          if [[ "${{ needs.build-tauri.result }}" != "success" ]]; then
+          if [[ "${{ needs.build-tauri.result }}" == "success" ]]; then
+            echo "✅ Tauri build passed"
+          elif [[ "${{ needs.build-tauri.result }}" == "skipped" ]]; then
+            echo "ℹ️ Some Tauri builds skipped (main-only platforms)"
+          else
             echo "❌ Tauri build failed"
             exit 1
-          else
-            echo "✅ Tauri build passed"
           fi
 
       - name: Check Docker build results
@@ -225,7 +228,8 @@ jobs:
               echo "⚠️ Unit tests failed"
             fi
             echo "✅ Standard build succeeded"
-            echo "ℹ️ Tauri and Docker builds skipped for PR"
+            echo "✅ Tauri macOS aarch64 build checked"
+            echo "ℹ️ Other Tauri and Docker builds skipped for PR"
           else
             echo "🎉 All builds completed!"
             if [[ "${{ needs.test.result }}" == "success" ]]; then

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "test:ci": "jest --ci --coverage --maxWorkers=2",
     "db:setup-test": "bun run scripts/setup-test-db.ts",
     "dev:desktop": "DEPLOYMENT_MODE=desktop bun run dev",
-    "build:desktop": "DEPLOYMENT_MODE=desktop next build",
     "tauri:dev": "concurrently \"bun run dev:desktop\" \"tauri dev\"",
     "tauri:build": "bun run build:desktop && tauri build",
     "tauri:build:windows": "tauri build --target x86_64-pc-windows-msvc",

--- a/scripts/clean-tauri-dist.mjs
+++ b/scripts/clean-tauri-dist.mjs
@@ -1,0 +1,21 @@
+/**
+ * Post-build cleanup for Tauri desktop builds.
+ * Removes node_modules from .next/standalone to prevent Tauri from
+ * rejecting the frontendDist directory.
+ */
+import { rmSync, existsSync } from 'fs';
+import { join } from 'path';
+
+const targets = [
+  join('.next', 'standalone', 'node_modules'),
+  join('.next', 'standalone', '.next', 'cache'),
+];
+
+for (const target of targets) {
+  if (existsSync(target)) {
+    rmSync(target, { recursive: true, force: true });
+    console.log(`Removed ${target}`);
+  }
+}
+
+console.log('Tauri dist cleanup complete');

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "frontendDist": "../.next/standalone",
     "devUrl": "http://localhost:3000",
-    "beforeBuildCommand": "bun run build:desktop"
+    "beforeBuildCommand": "bun run build:desktop && node scripts/clean-tauri-dist.mjs"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary
- Tauri v2 now rejects `frontendDist` directories containing `node_modules`. Next.js standalone output at `.next/standalone` includes `node_modules`, causing all Tauri builds to fail.
- Added `scripts/clean-tauri-dist.mjs` post-build cleanup that removes `node_modules` and `cache` from standalone output before Tauri packages it.
- Updated `beforeBuildCommand` in `tauri.conf.json` to run cleanup after build.
- Removed duplicate `build:desktop` key in `package.json`.
- macOS aarch64 Tauri build now runs on PRs (not just push to main) to catch build issues early.

## Test plan
- [ ] PR CI should trigger macOS aarch64 Tauri build and pass
- [ ] Verify the cleanup script runs successfully in CI logs
- [ ] Confirm no `node_modules` error from Tauri

🤖 Generated with [Claude Code](https://claude.com/claude-code)