### PR TITLE
ENG-825 feat: client feedback round 1 — checkout flow, receipts, tax, UX

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -39,6 +39,16 @@
       "title": "No Tables Found",
       "subtitle": "Get started by creating your first billiard table",
       "button": "Create Your First Table"
+    },
+    "stopConfirmation": {
+      "title": "Stop Session",
+      "message": "Are you sure you want to stop the session for {tableName}?",
+      "currentDuration": "Current duration",
+      "confirm": "Yes, Stop Session",
+      "cancel": "Cancel"
+    },
+    "timeExpired": {
+      "notification": "Time is up for {tableName}!"
     }
   },
   "TableCard": {
@@ -956,6 +966,39 @@
       "noteText": "Current tax rate in Indonesia is 11% (PPN). Changes will apply to new orders and sessions only.",
       "saving": "Saving...",
       "saveTaxSettings": "Save Tax Settings"
+    },
+    "storeSettings": {
+      "title": "Store Information",
+      "subtitle": "Configure your billiard hall details for receipts",
+      "storeName": "Store Name",
+      "storeNamePlaceholder": "e.g., Chalkboard Billiard",
+      "storeAddress": "Address",
+      "storeAddressPlaceholder": "e.g., Jl. Sudirman No. 123",
+      "storePhone": "Phone Number",
+      "storePhonePlaceholder": "e.g., 021-1234567",
+      "storeNotes": "Additional Notes (printed on receipt)",
+      "storeNotesPlaceholder": "e.g., WiFi Password: billiard123",
+      "saving": "Saving...",
+      "saveStoreSettings": "Save Store Settings"
+    },
+    "defaultStaff": {
+      "title": "Default Staff",
+      "subtitle": "Set a default staff member to reduce selection friction",
+      "selectStaff": "Select Default Staff",
+      "noDefault": "No default (manual selection required)",
+      "saving": "Saving...",
+      "saveDefaultStaff": "Save Default Staff"
+    },
+    "checkout": {
+      "printAndSave": "Print & Save",
+      "adjustDuration": "Adjust Duration",
+      "taxBreakdown": "Tax Breakdown",
+      "tableTax": "Table Tax",
+      "fnbTax": "F&B Tax",
+      "duration": "Duration",
+      "hours": "Hours",
+      "minutes": "Minutes",
+      "seconds": "Seconds"
     }
   },
   "PricingPackages": {

--- a/messages/id.json
+++ b/messages/id.json
@@ -39,6 +39,16 @@
       "title": "Tidak Ada Meja Ditemukan",
       "subtitle": "Mulailah dengan membuat meja biliar pertama Anda",
       "button": "Buat Meja Pertama Anda"
+    },
+    "stopConfirmation": {
+      "title": "Hentikan Sesi",
+      "message": "Apakah Anda yakin ingin menghentikan sesi untuk {tableName}?",
+      "currentDuration": "Durasi saat ini",
+      "confirm": "Ya, Hentikan Sesi",
+      "cancel": "Batal"
+    },
+    "timeExpired": {
+      "notification": "Waktu habis untuk {tableName}!"
     }
   },
   "TableCard": {
@@ -957,6 +967,39 @@
       "noteText": "Tarif pajak saat ini di Indonesia adalah 11% (PPN). Perubahan akan berlaku untuk pesanan dan sesi baru saja.",
       "saving": "Menyimpan...",
       "saveTaxSettings": "Simpan Pengaturan Pajak"
+    },
+    "storeSettings": {
+      "title": "Informasi Toko",
+      "subtitle": "Konfigurasi detail billiard hall untuk struk",
+      "storeName": "Nama Toko",
+      "storeNamePlaceholder": "contoh: Chalkboard Billiard",
+      "storeAddress": "Alamat",
+      "storeAddressPlaceholder": "contoh: Jl. Sudirman No. 123",
+      "storePhone": "Nomor Telepon",
+      "storePhonePlaceholder": "contoh: 021-1234567",
+      "storeNotes": "Catatan Tambahan (dicetak pada struk)",
+      "storeNotesPlaceholder": "contoh: Password WiFi: billiard123",
+      "saving": "Menyimpan...",
+      "saveStoreSettings": "Simpan Pengaturan Toko"
+    },
+    "defaultStaff": {
+      "title": "Staff Default",
+      "subtitle": "Atur staff default untuk mengurangi proses seleksi",
+      "selectStaff": "Pilih Staff Default",
+      "noDefault": "Tidak ada default (pilih manual)",
+      "saving": "Menyimpan...",
+      "saveDefaultStaff": "Simpan Staff Default"
+    },
+    "checkout": {
+      "printAndSave": "Cetak & Simpan",
+      "adjustDuration": "Sesuaikan Durasi",
+      "taxBreakdown": "Rincian Pajak",
+      "tableTax": "Pajak Meja",
+      "fnbTax": "Pajak F&B",
+      "duration": "Durasi",
+      "hours": "Jam",
+      "minutes": "Menit",
+      "seconds": "Detik"
     }
   },
   "PricingPackages": {

--- a/src/app/[locale]/(DashboardLayout)/admin/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/admin/page.tsx
@@ -3,8 +3,8 @@ import React, { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from 'next-intl';
-import { Alert, Card, Button, Label, TextInput, Checkbox } from "flowbite-react";
-import { IconSettings, IconCheck, IconX, IconPercentage } from "@tabler/icons-react";
+import { Alert, Card, Button, Label, TextInput, Checkbox, Select, Textarea } from "flowbite-react";
+import { IconSettings, IconCheck, IconX, IconPercentage, IconBuilding, IconUser } from "@tabler/icons-react";
 import DefaultSpinner from "@/components/ui-components/Spinner/DefaultSpinner";
 
 export default function AdminPage() {
@@ -21,6 +21,16 @@ export default function AdminPage() {
     applyToFnb: true
   });
   const [loading, setLoading] = useState(false);
+  const [storeSettings, setStoreSettings] = useState({
+    store_name: '',
+    store_address: '',
+    store_phone: '',
+    store_notes: ''
+  });
+  const [storeLoading, setStoreLoading] = useState(false);
+  const [staffList, setStaffList] = useState<{ id: number; name: string; role: string }[]>([]);
+  const [defaultStaffId, setDefaultStaffId] = useState('');
+  const [staffLoading, setStaffLoading] = useState(false);
 
   useEffect(() => {
     if (status === "loading") return;
@@ -29,6 +39,8 @@ export default function AdminPage() {
       return;
     }
     fetchTaxSettings();
+    fetchStoreSettings();
+    fetchStaffData();
   }, [session, status, router]);
 
   const fetchTaxSettings = async () => {
@@ -40,6 +52,74 @@ export default function AdminPage() {
       }
     } catch (error) {
       console.error('Failed to fetch tax settings:', error);
+    }
+  };
+
+  const fetchStoreSettings = async () => {
+    try {
+      const response = await fetch('/api/admin/settings');
+      if (response.ok) {
+        const data = await response.json();
+        const s = data.settings || {};
+        setStoreSettings({
+          store_name: s.store_name || '',
+          store_address: s.store_address || '',
+          store_phone: s.store_phone || '',
+          store_notes: s.store_notes || ''
+        });
+        setDefaultStaffId(s.default_staff_id || '');
+      }
+    } catch (error) {
+      console.error('Failed to fetch store settings:', error);
+    }
+  };
+
+  const fetchStaffData = async () => {
+    try {
+      const response = await fetch('/api/staff?active=true');
+      if (response.ok) {
+        const data = await response.json();
+        setStaffList(data);
+      }
+    } catch (error) {
+      console.error('Failed to fetch staff:', error);
+    }
+  };
+
+  const handleStoreSettingsSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStoreLoading(true);
+    try {
+      const entries = Object.entries(storeSettings);
+      for (const [key, value] of entries) {
+        await fetch('/api/admin/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key, value: value || ' ', description: `Store ${key}` }),
+        });
+      }
+      setAlert({ type: 'success', message: 'Store settings saved successfully' });
+    } catch (error) {
+      setAlert({ type: 'error', message: 'Failed to save store settings' });
+    } finally {
+      setStoreLoading(false);
+    }
+  };
+
+  const handleDefaultStaffSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStaffLoading(true);
+    try {
+      await fetch('/api/admin/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'default_staff_id', value: defaultStaffId || '0', description: 'Default staff member ID' }),
+      });
+      setAlert({ type: 'success', message: 'Default staff saved successfully' });
+    } catch (error) {
+      setAlert({ type: 'error', message: 'Failed to save default staff' });
+    } finally {
+      setStaffLoading(false);
     }
   };
 
@@ -182,6 +262,109 @@ export default function AdminPage() {
               <div className="flex justify-end">
                 <Button type="submit" disabled={loading}>
                   {loading ? t('taxSettings.saving') : t('taxSettings.saveTaxSettings')}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </Card>
+
+        {/* Store Settings Card */}
+        <Card>
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-xl font-semibold text-dark dark:text-white mb-2 flex items-center gap-2">
+                <IconBuilding className="h-5 w-5" />
+                {t('storeSettings.title')}
+              </h3>
+              <p className="text-bodytext text-sm mb-4">
+                {t('storeSettings.subtitle')}
+              </p>
+            </div>
+
+            <form onSubmit={handleStoreSettingsSubmit} className="space-y-4">
+              <div>
+                <Label htmlFor="storeName">{t('storeSettings.storeName')}</Label>
+                <TextInput
+                  id="storeName"
+                  value={storeSettings.store_name}
+                  onChange={(e) => setStoreSettings({ ...storeSettings, store_name: e.target.value })}
+                  placeholder={t('storeSettings.storeNamePlaceholder')}
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="storeAddress">{t('storeSettings.storeAddress')}</Label>
+                <TextInput
+                  id="storeAddress"
+                  value={storeSettings.store_address}
+                  onChange={(e) => setStoreSettings({ ...storeSettings, store_address: e.target.value })}
+                  placeholder={t('storeSettings.storeAddressPlaceholder')}
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="storePhone">{t('storeSettings.storePhone')}</Label>
+                <TextInput
+                  id="storePhone"
+                  value={storeSettings.store_phone}
+                  onChange={(e) => setStoreSettings({ ...storeSettings, store_phone: e.target.value })}
+                  placeholder={t('storeSettings.storePhonePlaceholder')}
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="storeNotes">{t('storeSettings.storeNotes')}</Label>
+                <Textarea
+                  id="storeNotes"
+                  rows={3}
+                  value={storeSettings.store_notes}
+                  onChange={(e) => setStoreSettings({ ...storeSettings, store_notes: e.target.value })}
+                  placeholder={t('storeSettings.storeNotesPlaceholder')}
+                />
+              </div>
+
+              <div className="flex justify-end">
+                <Button type="submit" disabled={storeLoading}>
+                  {storeLoading ? t('storeSettings.saving') : t('storeSettings.saveStoreSettings')}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </Card>
+
+        {/* Default Staff Card */}
+        <Card>
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-xl font-semibold text-dark dark:text-white mb-2 flex items-center gap-2">
+                <IconUser className="h-5 w-5" />
+                {t('defaultStaff.title')}
+              </h3>
+              <p className="text-bodytext text-sm mb-4">
+                {t('defaultStaff.subtitle')}
+              </p>
+            </div>
+
+            <form onSubmit={handleDefaultStaffSubmit} className="space-y-4">
+              <div>
+                <Label htmlFor="defaultStaff">{t('defaultStaff.selectStaff')}</Label>
+                <Select
+                  id="defaultStaff"
+                  value={defaultStaffId}
+                  onChange={(e) => setDefaultStaffId(e.target.value)}
+                >
+                  <option value="">{t('defaultStaff.noDefault')}</option>
+                  {staffList.map((s) => (
+                    <option key={s.id} value={String(s.id)}>
+                      {s.name} - {s.role}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+
+              <div className="flex justify-end">
+                <Button type="submit" disabled={staffLoading}>
+                  {staffLoading ? t('defaultStaff.saving') : t('defaultStaff.saveDefaultStaff')}
                 </Button>
               </div>
             </form>

--- a/src/app/[locale]/(DashboardLayout)/dashboard/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/dashboard/page.tsx
@@ -95,7 +95,11 @@ const ChalkBoardDashboard = () => {
       const response = await fetch('/api/tables');
       if (response.ok) {
         const data = await response.json();
-        const sortedTables = data.sort((a: Table, b: Table) => a.id - b.id);
+        const sortedTables = data.sort((a: Table, b: Table) => {
+          const numA = parseInt((a.name.match(/(\d+)/) || ['0', '0'])[1], 10);
+          const numB = parseInt((b.name.match(/(\d+)/) || ['0', '0'])[1], 10);
+          return numA - numB || a.name.localeCompare(b.name);
+        });
         setTables(sortedTables);
         
         // Calculate stats

--- a/src/app/[locale]/(DashboardLayout)/tables/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/tables/page.tsx
@@ -200,6 +200,7 @@ const TablesManagement = () => {
 
   const [currentTime, setCurrentTime] = useState(new Date());
   const autoEndTriggeredRef = useRef<Set<number>>(new Set());
+  const defaultStaffIdRef = useRef<string>('');
   const [pricingPackages, setPricingPackages] = useState<PricingPackage[]>([]);
   const [showStopConfirmModal, setShowStopConfirmModal] = useState(false);
   const [tableToStop, setTableToStop] = useState<BilliardTable | null>(null);
@@ -333,6 +334,7 @@ const TablesManagement = () => {
         const data = await response.json();
         const defaultId = data.settings?.default_staff_id;
         if (defaultId && defaultId !== '0') {
+          defaultStaffIdRef.current = defaultId;
           setSelectedStaffId(defaultId);
         }
       }
@@ -524,7 +526,7 @@ const TablesManagement = () => {
         const orderResult = await response.json();
         showAlert('success', tAlerts('orderCreatedAddedToBill', { orderNumber: orderResult.orderNumber, tableName: selectedTable.name }));
         clearCart();
-        setSelectedStaffId('');
+        setSelectedStaffId(defaultStaffIdRef.current);
         // Refresh existing orders to show the new order
         if (selectedTable) {
           await fetchExistingOrders(selectedTable.id);

--- a/src/app/[locale]/(DashboardLayout)/tables/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/tables/page.tsx
@@ -200,6 +200,8 @@ const TablesManagement = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
   const autoEndTriggeredRef = useRef<Set<number>>(new Set());
   const [pricingPackages, setPricingPackages] = useState<PricingPackage[]>([]);
+  const [showStopConfirmModal, setShowStopConfirmModal] = useState(false);
+  const [tableToStop, setTableToStop] = useState<BilliardTable | null>(null);
 
   // Redirect if not authenticated
   useEffect(() => {
@@ -214,7 +216,11 @@ const TablesManagement = () => {
       const response = await fetch('/api/tables');
       if (response.ok) {
         const data = await response.json();
-        const sortedTables = data.sort((a: BilliardTable, b: BilliardTable) => a.id - b.id);
+        const sortedTables = data.sort((a: BilliardTable, b: BilliardTable) => {
+          const numA = parseInt((a.name.match(/(\d+)/) || ['0', '0'])[1], 10);
+          const numB = parseInt((b.name.match(/(\d+)/) || ['0', '0'])[1], 10);
+          return numA - numB || a.name.localeCompare(b.name);
+        });
         setTables(sortedTables);
         
         // Fetch current sessions for occupied tables
@@ -315,8 +321,24 @@ const TablesManagement = () => {
       fetchTables();
       fetchTaxSettings();
       fetchPricingPackages();
+      fetchDefaultStaff();
     }
   }, [session]);
+
+  const fetchDefaultStaff = async () => {
+    try {
+      const response = await fetch('/api/admin/settings');
+      if (response.ok) {
+        const data = await response.json();
+        const defaultId = data.settings?.default_staff_id;
+        if (defaultId && defaultId !== '0') {
+          setSelectedStaffId(defaultId);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to fetch default staff:', error);
+    }
+  };
 
   const fetchTaxSettings = async () => {
     try {
@@ -339,18 +361,17 @@ const TablesManagement = () => {
     return () => clearInterval(timer);
   }, []);
 
-  // Auto end planned sessions when time is up
+  // Show notification when planned sessions expire (no auto-stop)
   useEffect(() => {
     tables.forEach((table) => {
-      const session = sessions[table.id];
-      if (!session) return;
-      if ((session.plannedDuration || 0) <= 0) return; // open mode
-      const elapsed = calculateElapsedTime(session.startTime);
-      const remaining = session.plannedDuration * 60 - elapsed;
+      const tableSession = sessions[table.id];
+      if (!tableSession) return;
+      if ((tableSession.plannedDuration || 0) <= 0) return; // open mode
+      const elapsed = calculateElapsedTime(tableSession.startTime);
+      const remaining = tableSession.plannedDuration * 60 - elapsed;
       if (remaining <= 0 && !autoEndTriggeredRef.current.has(table.id)) {
         autoEndTriggeredRef.current.add(table.id);
-        // Fire and forget; UI will refresh via fetchTables in handler
-        handleEndSession(table.id);
+        showAlert('error', t('timeExpired.notification', { tableName: table.name }));
       }
     });
   }, [currentTime, sessions, tables]);
@@ -752,11 +773,168 @@ const TablesManagement = () => {
     fetchTables();
   };
 
-  const handleBillingConfirm = (finalBillingData: any) => {
-    // Process payment with final billing data
-    showAlert('success', tAlerts('paymentProcessedSuccess'));
-    setShowBillingModal(false);
-    setBillingData(null);
+  const handleBillingConfirm = async (finalBillingData: any) => {
+    try {
+      const billing = finalBillingData.billing;
+      const response = await fetch('/api/payments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: billing.sessionId || finalBillingData.session.id,
+          tableId: billing.tableId,
+          customerName: billing.customerName || finalBillingData.session.customerName,
+          customerPhone: billing.customerPhone || finalBillingData.session.customerPhone,
+          tableAmount: billing.tableCost,
+          fnbAmount: billing.fnbTotalCost,
+          taxAmount: billing.totalTaxAmount || 0,
+          totalAmount: billing.totalCost,
+          staffId: billing.staffId,
+          paymentMethods: [{ type: 'cash', amount: billing.totalCost }],
+        }),
+      });
+
+      if (response.ok) {
+        const paymentData = await response.json();
+        // Print receipt
+        printCheckoutReceipt(paymentData, finalBillingData);
+        showAlert('success', tAlerts('paymentProcessedSuccess'));
+        setShowBillingModal(false);
+        setBillingData(null);
+        fetchTables();
+      } else {
+        const error = await response.json();
+        showAlert('error', error.error || 'Failed to process payment');
+      }
+    } catch (error) {
+      showAlert('error', 'Failed to process payment');
+    }
+  };
+
+  const printCheckoutReceipt = (paymentData: any, billingData: any) => {
+    const billing = billingData.billing;
+    const session = billingData.session;
+
+    const formatCurrencyReceipt = (amount: number) =>
+      new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR', minimumFractionDigits: 0 }).format(amount);
+
+    // Fetch store settings for receipt
+    fetch('/api/admin/settings')
+      .then(res => res.json())
+      .then(data => {
+        const s = data.settings || {};
+        const storeName = (s.store_name || 'CHALKBOARD BILLIARD').trim();
+        const storeAddress = (s.store_address || '').trim();
+        const storePhone = (s.store_phone || '').trim();
+        const storeNotes = (s.store_notes || '').trim();
+
+        const fnbSection = billing.fnbOrders && billing.fnbOrders.length > 0
+          ? `<div class="section">
+              <h3>F&B ORDERS</h3>
+              ${billing.fnbOrders.map((order: any) =>
+                `<div class="item-row">
+                  <span class="item-name">${order.orderNumber}</span>
+                  <span class="item-price">${formatCurrencyReceipt(parseFloat(order.total))}</span>
+                </div>`
+              ).join('')}
+            </div>`
+          : '';
+
+        const taxSection = billing.totalTaxAmount > 0
+          ? `<div class="subtotal-row">
+              <span>${billing.taxSettings?.name || 'Tax'} (${billing.taxSettings?.percentage || 0}%):</span>
+              <span>${formatCurrencyReceipt(billing.totalTaxAmount)}</span>
+            </div>`
+          : '';
+
+        const receiptHtml = `
+          <!DOCTYPE html>
+          <html><head>
+            <meta charset="UTF-8">
+            <title>Receipt - ${paymentData.transactionNumber}</title>
+            <style>
+              body { font-family: 'Courier New', monospace; max-width: 300px; margin: 0 auto; padding: 10px; font-size: 12px; line-height: 1.4; }
+              .header { text-align: center; border-bottom: 2px dashed #000; padding-bottom: 10px; margin-bottom: 10px; }
+              .header h1 { margin: 0; font-size: 16px; font-weight: bold; }
+              .header p { margin: 2px 0; font-size: 10px; }
+              .section { margin: 10px 0; border-bottom: 1px dashed #000; padding-bottom: 8px; }
+              .item-row { display: flex; justify-content: space-between; margin: 2px 0; }
+              .item-name { flex: 1; margin-right: 10px; }
+              .item-price { text-align: right; min-width: 60px; }
+              .subtotal-row { display: flex; justify-content: space-between; margin: 2px 0; }
+              .total-row { display: flex; justify-content: space-between; font-weight: bold; margin: 5px 0 2px 0; border-top: 1px solid #000; padding-top: 3px; }
+              .footer { text-align: center; margin-top: 15px; font-size: 10px; border-top: 2px dashed #000; padding-top: 10px; }
+              @media print { body { margin: 0; padding: 5px; } }
+            </style>
+          </head><body>
+            <div class="header">
+              <h1>${storeName.toUpperCase()}</h1>
+              ${storeAddress ? `<p>${storeAddress}</p>` : ''}
+              ${storePhone ? `<p>${storePhone}</p>` : ''}
+              <p>Struk Pembayaran</p>
+              <p style="font-size:13px; font-weight:bold; margin-top:4px">${paymentData.transactionNumber}</p>
+              <p>${new Date().toLocaleString('id-ID')}</p>
+            </div>
+
+            <div class="section">
+              <p><strong>Customer:</strong> ${session.customerName}</p>
+              ${session.customerPhone ? `<p><strong>Phone:</strong> ${session.customerPhone}</p>` : ''}
+            </div>
+
+            <div class="section">
+              <h3>TABLE SESSION</h3>
+              <div class="item-row">
+                <span class="item-name">
+                  Duration: ${billing.actualDuration} min
+                  (${billing.billingDetails.type === 'hourly'
+                    ? billing.billingDetails.billableHours + ' hr'
+                    : billing.billingDetails.billableMinutes + ' min'})
+                </span>
+                <span class="item-price">${formatCurrencyReceipt(billing.tableCost)}</span>
+              </div>
+            </div>
+
+            ${fnbSection}
+
+            <div class="section">
+              <h3>PAYMENT SUMMARY</h3>
+              <div class="subtotal-row">
+                <span>Table:</span>
+                <span>${formatCurrencyReceipt(billing.tableCost)}</span>
+              </div>
+              ${billing.fnbTotalCost > 0 ? `
+                <div class="subtotal-row">
+                  <span>F&B:</span>
+                  <span>${formatCurrencyReceipt(billing.fnbTotalCost)}</span>
+                </div>
+              ` : ''}
+              ${taxSection}
+              <div class="total-row">
+                <span>TOTAL:</span>
+                <span>${formatCurrencyReceipt(billing.totalCost)}</span>
+              </div>
+            </div>
+
+            <div class="footer">
+              <p>Terima kasih atas kunjungan Anda!</p>
+              ${storeNotes ? `<p style="margin-top:4px">${storeNotes}</p>` : ''}
+              <p>${storeName}</p>
+            </div>
+          </body></html>
+        `;
+
+        const printWindow = window.open('', '_blank', 'width=800,height=600');
+        if (printWindow) {
+          printWindow.document.write(receiptHtml);
+          printWindow.document.close();
+          printWindow.focus();
+          printWindow.print();
+          printWindow.close();
+        }
+      })
+      .catch(() => {
+        // Silently fail on receipt — payment was already saved
+        console.error('Failed to print receipt');
+      });
   };
 
   const getStatusColor = (status: string) => {
@@ -1131,7 +1309,7 @@ const TablesManagement = () => {
                         color="error"
                         size="xs"
                         className="flex-1"
-                        onClick={() => handleEndSession(table.id)}
+                        onClick={() => { setTableToStop(table); setShowStopConfirmModal(true); }}
                       >
                         <IconPlayerStop className="w-3 h-3 mr-1" />
                         {tCards('stopButton')}
@@ -1755,7 +1933,6 @@ const TablesManagement = () => {
               sessionId={selectedSession.id}
               currentDurationType={(selectedSession as any).durationType || 'hourly'}
               elapsedMinutes={calculateElapsedTime(selectedSession.startTime) / 60}
-              onDurationTypeChange={(newType) => handleDurationTypeChange(selectedSession.id, newType)}
               onDurationUpdate={(newDuration) => handleDurationUpdate(selectedSession.id, newDuration)}
             />
           )}
@@ -1763,6 +1940,48 @@ const TablesManagement = () => {
         <Modal.Footer>
           <Button color="secondary" onClick={() => setShowDurationModal(false)}>
             {tCommon('close')}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      {/* Stop Session Confirmation Modal */}
+      <Modal show={showStopConfirmModal} onClose={() => setShowStopConfirmModal(false)} size="md">
+        <Modal.Header>{t('stopConfirmation.title')}</Modal.Header>
+        <Modal.Body>
+          <div className="space-y-4">
+            <p className="text-dark dark:text-white">
+              {t('stopConfirmation.message', { tableName: tableToStop?.name || '' })}
+            </p>
+            {tableToStop && sessions[tableToStop.id] && (
+              <div className="bg-lightgray dark:bg-darkgray p-3 rounded-lg">
+                <p className="text-sm text-bodytext">
+                  {t('stopConfirmation.currentDuration')}:{' '}
+                  <span className="font-medium text-dark dark:text-white">
+                    {Math.floor(calculateElapsedTime(sessions[tableToStop.id].startTime) / 60)} {tCommon('minutes')}
+                  </span>
+                </p>
+              </div>
+            )}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            color="error"
+            onClick={() => {
+              if (tableToStop) {
+                handleEndSession(tableToStop.id);
+              }
+              setShowStopConfirmModal(false);
+              setTableToStop(null);
+            }}
+          >
+            {t('stopConfirmation.confirm')}
+          </Button>
+          <Button
+            color="secondary"
+            onClick={() => { setShowStopConfirmModal(false); setTableToStop(null); }}
+          >
+            {t('stopConfirmation.cancel')}
           </Button>
         </Modal.Footer>
       </Modal>

--- a/src/app/[locale]/(DashboardLayout)/tables/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/tables/page.tsx
@@ -831,10 +831,17 @@ const TablesManagement = () => {
           ? `<div class="section">
               <h3>F&B ORDERS</h3>
               ${billing.fnbOrders.map((order: any) =>
-                `<div class="item-row">
-                  <span class="item-name">${order.orderNumber}</span>
-                  <span class="item-price">${formatCurrencyReceipt(parseFloat(order.total))}</span>
-                </div>`
+                order.items && order.items.length > 0
+                  ? order.items.map((item: any) =>
+                      `<div class="item-row">
+                        <span class="item-name">${item.quantity}x ${item.itemName || 'Item'}</span>
+                        <span class="item-price">${formatCurrencyReceipt(parseFloat(item.subtotal))}</span>
+                      </div>`
+                    ).join('')
+                  : `<div class="item-row">
+                      <span class="item-name">${order.orderNumber}</span>
+                      <span class="item-price">${formatCurrencyReceipt(parseFloat(order.total))}</span>
+                    </div>`
               ).join('')}
             </div>`
           : '';

--- a/src/app/[locale]/(DashboardLayout)/tables/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/tables/page.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import { Button, Badge, Modal, TextInput, Label, Select, Alert, Tabs } from "flowbite-react";
 import { 
   IconPlus, 
@@ -143,6 +143,7 @@ const TablesManagement = () => {
   const sessionHook = useSession();
   const { data: session, status } = sessionHook || { data: null, status: 'loading' };
   const router = useRouter();
+  const locale = useLocale();
   const t = useTranslations('TablesManagement');
   const tCards = useTranslations('TableCard');
   const tAlerts = useTranslations('Alerts');
@@ -797,10 +798,10 @@ const TablesManagement = () => {
         const paymentData = await response.json();
         // Print receipt
         printCheckoutReceipt(paymentData, finalBillingData);
-        showAlert('success', tAlerts('paymentProcessedSuccess'));
         setShowBillingModal(false);
         setBillingData(null);
-        fetchTables();
+        // Redirect to transactions page with payment modal auto-open
+        router.push(`/${locale}/transactions?paymentId=${paymentData.id}`);
       } else {
         const error = await response.json();
         showAlert('error', error.error || 'Failed to process payment');

--- a/src/app/[locale]/(DashboardLayout)/transactions/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/transactions/page.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from 'next-intl';
 import CardBox from "@/components/shared/CardBox";
 import { Button, Badge, Table, Modal, Alert, Select, Label, TextInput } from "flowbite-react";
@@ -88,6 +88,7 @@ const TransactionsPage = () => {
   const sessionHook = useSession();
   const { data: session, status } = sessionHook || { data: null, status: 'loading' };
   const router = useRouter();
+  const searchParams = useSearchParams();
   const t = useTranslations();
   const tAlerts = useTranslations('Alerts');
   const [payments, setPayments] = useState<Payment[]>([]);
@@ -299,6 +300,20 @@ const TransactionsPage = () => {
       showAlert('error', tAlerts('failedToCancelPayment'));
     }
   };
+
+  // Auto-open payment modal when redirected from checkout with paymentId param
+  useEffect(() => {
+    const paymentId = searchParams.get('paymentId');
+    if (paymentId && payments.length > 0) {
+      const payment = payments.find(p => p.id === parseInt(paymentId));
+      if (payment) {
+        setSelectedPayment(payment);
+        setShowPaymentModal(true);
+        // Clean up the URL param
+        router.replace(window.location.pathname, { scroll: false });
+      }
+    }
+  }, [payments, searchParams]);
 
   const openPaymentModal = (payment: Payment) => {
     setSelectedPayment(payment);

--- a/src/app/[locale]/(DashboardLayout)/transactions/page.tsx
+++ b/src/app/[locale]/(DashboardLayout)/transactions/page.tsx
@@ -105,6 +105,12 @@ const TransactionsPage = () => {
     applyToTables: false,
     applyToFnb: true
   });
+  const [storeSettings, setStoreSettings] = useState({
+    store_name: '',
+    store_address: '',
+    store_phone: '',
+    store_notes: ''
+  });
 
   // Filter states
   const [statusFilter, setStatusFilter] = useState<string>('all');
@@ -139,6 +145,7 @@ const TransactionsPage = () => {
     if (session) {
       fetchPayments();
       fetchTaxSettings();
+      fetchStoreSettings();
     }
   }, [session]);
 
@@ -151,6 +158,24 @@ const TransactionsPage = () => {
       }
     } catch (error) {
       console.error('Failed to fetch tax settings:', error);
+    }
+  };
+
+  const fetchStoreSettings = async () => {
+    try {
+      const response = await fetch('/api/admin/settings');
+      if (response.ok) {
+        const data = await response.json();
+        const s = data.settings || {};
+        setStoreSettings({
+          store_name: (s.store_name || '').trim(),
+          store_address: (s.store_address || '').trim(),
+          store_phone: (s.store_phone || '').trim(),
+          store_notes: (s.store_notes || '').trim()
+        });
+      }
+    } catch (error) {
+      console.error('Failed to fetch store settings:', error);
     }
   };
 
@@ -310,8 +335,9 @@ const TransactionsPage = () => {
       (locale === 'id' ? 'Pajak' : 'Tax');
     
     // Create a temporary translations object for the selected locale
+    const storeName = storeSettings.store_name || (locale === 'id' ? 'BILLIARD CHALKBOARD' : 'CHALKBOARD BILLIARD');
     const receiptTranslations = locale === 'id' ? {
-      title: 'BILLIARD CHALKBOARD',
+      title: storeName.toUpperCase(),
       subtitle: 'Struk Pembayaran',
       transaction: 'Transaksi',
       date: 'Tanggal',
@@ -331,14 +357,14 @@ const TransactionsPage = () => {
       total: 'TOTAL',
       walkInCustomer: 'Pelanggan Walk-in',
       thankYou: 'Terima kasih atas kunjungan Anda!',
-      businessName: 'Billiard Hall ChalkBoard',
+      businessName: storeSettings.store_name || 'Billiard Hall ChalkBoard',
       generated: 'Dicetak',
       pending: 'TERTUNDA',
       success: 'BERHASIL',
       failed: 'GAGAL',
       cancelled: 'DIBATALKAN'
     } : {
-      title: 'CHALKBOARD BILLIARD',
+      title: storeName.toUpperCase(),
       subtitle: 'Receipt',
       transaction: 'Transaction',
       date: 'Date',
@@ -358,7 +384,7 @@ const TransactionsPage = () => {
       total: 'TOTAL',
       walkInCustomer: 'Walk-in Customer',
       thankYou: 'Thank you for visiting!',
-      businessName: 'ChalkBoard Billiard Hall',
+      businessName: storeSettings.store_name || 'ChalkBoard Billiard Hall',
       generated: 'Generated',
       pending: 'PENDING',
       success: 'SUCCESS',
@@ -466,8 +492,10 @@ const TransactionsPage = () => {
       <body>
         <div class="header">
           <h1>${receiptTranslations.title}</h1>
+          ${storeSettings.store_address ? `<p>${storeSettings.store_address}</p>` : ''}
+          ${storeSettings.store_phone ? `<p>${storeSettings.store_phone}</p>` : ''}
           <p>${receiptTranslations.subtitle}</p>
-          <p>${receiptTranslations.transaction}: ${payment.transactionNumber}</p>
+          <p style="font-size:13px; font-weight:bold; margin-top:4px">${receiptTranslations.transaction}: ${payment.transactionNumber}</p>
           <p>${receiptTranslations.date}: ${formatDateTime(payment.createdAt)}</p>
         </div>
 
@@ -544,6 +572,7 @@ const TransactionsPage = () => {
 
         <div class="footer">
           <p>${receiptTranslations.thankYou}</p>
+          ${storeSettings.store_notes ? `<p style="margin-top:4px">${storeSettings.store_notes}</p>` : ''}
           <p>${receiptTranslations.businessName}</p>
           <p>${receiptTranslations.generated}: ${new Date().toLocaleString(locale === 'id' ? 'id-ID' : 'en-US')}</p>
         </div>

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -3,7 +3,7 @@ import { db } from '@/lib/db';
 import { payments } from '@/schema/payments';
 import { tableSessions, tables } from '@/schema/tables';
 import { fnbOrders, fnbOrderItems, fnbItems, fnbCategories, staff } from '@/schema/fnb';
-import { eq, sql } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
 import { auth } from '@/lib/auth';
 
 export async function GET(request: NextRequest) {
@@ -226,6 +226,17 @@ export async function POST(request: NextRequest) {
       await db.update(fnbOrders)
         .set({ paymentId })
         .where(eq(fnbOrders.id, parseInt(orderId)));
+    }
+
+    // Link pending FnB orders for this table to the payment (checkout flow)
+    const tableId = body.tableId;
+    if (tableId) {
+      await db.update(fnbOrders)
+        .set({ paymentId, status: 'billed' })
+        .where(and(
+          eq(fnbOrders.tableId, parseInt(String(tableId))),
+          eq(fnbOrders.status, 'pending')
+        ));
     }
 
     return NextResponse.json({

--- a/src/app/api/table-sessions/[id]/recalculate-billing/route.ts
+++ b/src/app/api/table-sessions/[id]/recalculate-billing/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { tables, tableSessions } from '@/schema/tables';
 import { pricingPackages } from '@/schema/pricing-packages';
-import { fnbOrders } from '@/schema/fnb';
+import { fnbOrders, fnbOrderItems, fnbItems } from '@/schema/fnb';
 import { payments } from '@/schema/payments';
 import { eq, and } from 'drizzle-orm';
 import { auth } from '@/lib/auth';
@@ -123,6 +123,24 @@ export async function POST(
         ));
     }
 
+    // Fetch item details for each F&B order
+    const fnbOrdersWithItems = await Promise.all(
+      fnbOrdersForTable.map(async (order) => {
+        const items = await db
+          .select({
+            id: fnbOrderItems.id,
+            itemName: fnbItems.name,
+            quantity: fnbOrderItems.quantity,
+            unitPrice: fnbOrderItems.unitPrice,
+            subtotal: fnbOrderItems.subtotal,
+          })
+          .from(fnbOrderItems)
+          .leftJoin(fnbItems, eq(fnbOrderItems.itemId, fnbItems.id))
+          .where(eq(fnbOrderItems.orderId, order.id));
+        return { ...order, items };
+      })
+    );
+
     // Calculate total F&B cost
     const fnbTotalCost = fnbOrdersForTable.reduce((total, order) => {
       return total + parseFloat(order.total);
@@ -172,7 +190,7 @@ export async function POST(
         fnbTax,
         totalTaxAmount,
         totalCost,
-        fnbOrders: fnbOrdersForTable,
+        fnbOrders: fnbOrdersWithItems,
         taxSettings
       },
       message: 'Billing recalculated successfully'

--- a/src/app/api/table-sessions/[id]/recalculate-billing/route.ts
+++ b/src/app/api/table-sessions/[id]/recalculate-billing/route.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { tables, tableSessions } from '@/schema/tables';
+import { pricingPackages } from '@/schema/pricing-packages';
 import { fnbOrders } from '@/schema/fnb';
 import { payments } from '@/schema/payments';
 import { eq, and } from 'drizzle-orm';
 import { auth } from '@/lib/auth';
+import { getTaxSettings } from '@/lib/tax-server';
+import { calculateTax } from '@/lib/tax';
 
 export async function POST(
-  request: NextRequest, 
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -19,11 +22,11 @@ export async function POST(
     const { id } = await params;
     const sessionId = parseInt(id);
     const body = await request.json();
-    const { actualDuration, durationType } = body;
+    const { actualDuration } = body;
 
-    if (typeof actualDuration !== 'number' || !durationType) {
-      return NextResponse.json({ 
-        error: 'Actual duration and duration type are required' 
+    if (typeof actualDuration !== 'number') {
+      return NextResponse.json({
+        error: 'Actual duration is required'
       }, { status: 400 });
     }
 
@@ -33,63 +36,105 @@ export async function POST(
       .limit(1);
 
     if (targetSession.length === 0) {
-      return NextResponse.json({ 
-        error: 'Completed session not found' 
+      return NextResponse.json({
+        error: 'Completed session not found'
       }, { status: 404 });
     }
 
     const sessionData = targetSession[0];
     const tableId = sessionData.tableId;
 
-    // Get table rates for cost calculation
+    // Get pricing package for rates (mirrors end-session logic)
+    let pricingPackage;
+    if (sessionData.pricingPackageId) {
+      const packageResult = await db.select().from(pricingPackages)
+        .where(eq(pricingPackages.id, sessionData.pricingPackageId))
+        .limit(1);
+      pricingPackage = packageResult[0];
+    }
+
+    // Fallback to table rates
     const table = await db.select().from(tables).where(eq(tables.id, tableId)).limit(1);
     const tableData = table[0];
-    
+
+    // Derive billing type from package (locked to package)
+    let durationType: string;
+    if (pricingPackage) {
+      durationType = pricingPackage.category;
+    } else {
+      durationType = sessionData.durationType || (tableData.perMinuteRate ? 'per_minute' : 'hourly');
+    }
+
     let tableCost: number;
     let billingDetails: any;
 
     if (durationType === 'per_minute') {
-      // Per-minute billing
-      const perMinuteRate = tableData.perMinuteRate ? 
-        parseFloat(tableData.perMinuteRate) : 
-        parseFloat(tableData.hourlyRate) / 60;
-      
+      let perMinuteRate: number;
+      if (pricingPackage?.perMinuteRate) {
+        perMinuteRate = parseFloat(pricingPackage.perMinuteRate);
+      } else {
+        perMinuteRate = tableData.perMinuteRate ?
+          parseFloat(tableData.perMinuteRate) :
+          parseFloat(tableData.hourlyRate) / 60;
+      }
+
       tableCost = actualDuration * perMinuteRate;
-      
+
       billingDetails = {
         type: 'per_minute',
         rate: perMinuteRate,
         actualMinutes: actualDuration,
-        billableMinutes: actualDuration
+        billableMinutes: actualDuration,
+        packageName: pricingPackage?.name
       };
     } else {
-      // Hourly billing
-      const hourlyRate = parseFloat(tableData.hourlyRate);
+      let hourlyRate: number;
+      if (pricingPackage?.hourlyRate) {
+        hourlyRate = parseFloat(pricingPackage.hourlyRate);
+      } else {
+        hourlyRate = parseFloat(tableData.hourlyRate);
+      }
+
       const billableHours = Math.ceil(actualDuration / 60);
       tableCost = billableHours * hourlyRate;
-      
+
       billingDetails = {
         type: 'hourly',
         rate: hourlyRate,
         actualMinutes: actualDuration,
-        billableHours
+        billableHours,
+        packageName: pricingPackage?.name
       };
     }
-    
-    // Get F&B orders for this session
-    const fnbOrdersForTable = await db.select().from(fnbOrders)
-      .where(and(
-        eq(fnbOrders.tableId, tableId),
-        eq(fnbOrders.paymentId, sessionData.paymentId!)
-      ));
-    
+
+    // Get F&B orders for this table (pending or already linked to session's payment)
+    let fnbOrdersForTable;
+    if (sessionData.paymentId) {
+      fnbOrdersForTable = await db.select().from(fnbOrders)
+        .where(and(
+          eq(fnbOrders.tableId, tableId),
+          eq(fnbOrders.paymentId, sessionData.paymentId)
+        ));
+    } else {
+      fnbOrdersForTable = await db.select().from(fnbOrders)
+        .where(and(
+          eq(fnbOrders.tableId, tableId),
+          eq(fnbOrders.status, 'pending')
+        ));
+    }
+
     // Calculate total F&B cost
     const fnbTotalCost = fnbOrdersForTable.reduce((total, order) => {
       return total + parseFloat(order.total);
     }, 0);
-    
-    // Total cost = table cost + F&B cost
-    const totalCost = tableCost + fnbTotalCost;
+
+    // Calculate tax
+    const taxSettings = await getTaxSettings();
+    const tableTax = calculateTax(tableCost, taxSettings, true);
+    const fnbTax = calculateTax(fnbTotalCost, taxSettings, false);
+    const totalTaxAmount = tableTax + fnbTax;
+    const subtotal = tableCost + fnbTotalCost;
+    const totalCost = subtotal + totalTaxAmount;
 
     // Update the session with new duration and cost
     const updatedSession = await db.update(tableSessions)
@@ -101,13 +146,14 @@ export async function POST(
       .where(eq(tableSessions.id, sessionId))
       .returning();
 
-    // Update the associated payment record
+    // Update the associated payment record if it exists
     if (sessionData.paymentId) {
       await db.update(payments)
         .set({
           totalAmount: totalCost.toFixed(2),
           tableAmount: tableCost.toFixed(2),
           fnbAmount: fnbTotalCost.toFixed(2),
+          taxAmount: totalTaxAmount.toFixed(2),
           updatedAt: new Date(),
         })
         .where(eq(payments.id, sessionData.paymentId));
@@ -121,8 +167,13 @@ export async function POST(
         billingDetails,
         tableCost,
         fnbTotalCost,
+        subtotal,
+        tableTax,
+        fnbTax,
+        totalTaxAmount,
         totalCost,
-        fnbOrders: fnbOrdersForTable
+        fnbOrders: fnbOrdersForTable,
+        taxSettings
       },
       message: 'Billing recalculated successfully'
     });

--- a/src/app/api/tables/[id]/end-session/route.ts
+++ b/src/app/api/tables/[id]/end-session/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { tables, tableSessions } from '@/schema/tables';
 import { pricingPackages } from '@/schema/pricing-packages';
-import { fnbOrders } from '@/schema/fnb';
+import { fnbOrders, fnbOrderItems, fnbItems } from '@/schema/fnb';
 import { eq, and } from 'drizzle-orm';
 import { auth } from '@/lib/auth';
 import { getTaxSettings } from '@/lib/tax-server';
@@ -116,6 +116,24 @@ export async function POST(
         eq(fnbOrders.status, 'pending')
       ));
 
+    // Fetch item details for each F&B order
+    const fnbOrdersWithItems = await Promise.all(
+      fnbOrdersForTable.map(async (order) => {
+        const items = await db
+          .select({
+            id: fnbOrderItems.id,
+            itemName: fnbItems.name,
+            quantity: fnbOrderItems.quantity,
+            unitPrice: fnbOrderItems.unitPrice,
+            subtotal: fnbOrderItems.subtotal,
+          })
+          .from(fnbOrderItems)
+          .leftJoin(fnbItems, eq(fnbOrderItems.itemId, fnbItems.id))
+          .where(eq(fnbOrderItems.orderId, order.id));
+        return { ...order, items };
+      })
+    );
+
     // Calculate total F&B cost
     const fnbTotalCost = fnbOrdersForTable.reduce((total, order) => {
       return total + parseFloat(order.total);
@@ -171,7 +189,7 @@ export async function POST(
         fnbTax,
         totalTaxAmount,
         totalCost,
-        fnbOrders: fnbOrdersForTable,
+        fnbOrders: fnbOrdersWithItems,
         taxSettings
       }
     });

--- a/src/app/api/tables/[id]/end-session/route.ts
+++ b/src/app/api/tables/[id]/end-session/route.ts
@@ -3,14 +3,13 @@ import { db } from '@/lib/db';
 import { tables, tableSessions } from '@/schema/tables';
 import { pricingPackages } from '@/schema/pricing-packages';
 import { fnbOrders } from '@/schema/fnb';
-import { payments } from '@/schema/payments';
 import { eq, and } from 'drizzle-orm';
 import { auth } from '@/lib/auth';
 import { getTaxSettings } from '@/lib/tax-server';
 import { calculateTax } from '@/lib/tax';
 
 export async function POST(
-  request: NextRequest, 
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
@@ -35,7 +34,7 @@ export async function POST(
     const endTime = new Date();
     const startTime = new Date(currentSession.startTime);
     const calculatedDuration = Math.floor((endTime.getTime() - startTime.getTime()) / (1000 * 60)); // in minutes
-    
+
     // Use actual duration if manually set, otherwise use calculated duration
     const actualDuration = currentSession.actualDuration || calculatedDuration;
     const originalDuration = currentSession.originalDuration || calculatedDuration;
@@ -48,19 +47,19 @@ export async function POST(
         .limit(1);
       pricingPackage = packageResult[0];
     }
-    
+
     // Fallback to table rates if no package found (backwards compatibility)
     const table = await db.select().from(tables).where(eq(tables.id, tableId)).limit(1);
     const tableData = table[0];
-    
-    // Determine billing type based on package, session preference, or table configuration
+
+    // Determine billing type based on package (locked to package)
     let billingRateType: string;
     if (pricingPackage) {
       billingRateType = pricingPackage.category;
     } else {
       billingRateType = currentSession.durationType || (tableData.perMinuteRate ? 'per_minute' : 'hourly');
     }
-    
+
     let tableCost: number;
     let billingDetails: any;
 
@@ -72,15 +71,15 @@ export async function POST(
       } else {
         perMinuteRate = table[0].perMinuteRate ? parseFloat(table[0].perMinuteRate) : parseFloat(table[0].hourlyRate) / 60;
       }
-      
+
       const seconds = (endTime.getTime() - startTime.getTime()) / 1000;
       const minutes = Math.floor(seconds / 60);
       const remainingSeconds = seconds % 60;
-      
+
       // Round up if more than 30 seconds
       const billableMinutes = remainingSeconds > 30 ? minutes + 1 : minutes;
       tableCost = billableMinutes * perMinuteRate;
-      
+
       billingDetails = {
         type: 'per_minute',
         rate: perMinuteRate,
@@ -97,10 +96,10 @@ export async function POST(
       } else {
         hourlyRate = parseFloat(table[0].hourlyRate);
       }
-      
+
       const billableHours = Math.ceil(actualDuration / 60);
       tableCost = billableHours * hourlyRate;
-      
+
       billingDetails = {
         type: 'hourly',
         rate: hourlyRate,
@@ -109,33 +108,33 @@ export async function POST(
         packageName: pricingPackage?.name
       };
     }
-    
+
     // Get F&B orders for this table during the session
     const fnbOrdersForTable = await db.select().from(fnbOrders)
       .where(and(
         eq(fnbOrders.tableId, tableId),
         eq(fnbOrders.status, 'pending')
       ));
-    
+
     // Calculate total F&B cost
     const fnbTotalCost = fnbOrdersForTable.reduce((total, order) => {
       return total + parseFloat(order.total);
     }, 0);
-    
+
     // Get tax settings and calculate tax
     const taxSettings = await getTaxSettings();
-    
+
     // Calculate tax separately for table and F&B amounts
     const tableTax = calculateTax(tableCost, taxSettings, true); // isTable = true
     const fnbTax = calculateTax(fnbTotalCost, taxSettings, false); // isTable = false
     const totalTaxAmount = tableTax + fnbTax;
-    
+
     // Total cost before tax
     const subtotal = tableCost + fnbTotalCost;
     // Total cost including tax
     const totalCost = subtotal + totalTaxAmount;
 
-    // End the session
+    // End the session (mark as completed)
     const endedSession = await db.update(tableSessions)
       .set({
         endTime,
@@ -147,60 +146,20 @@ export async function POST(
       .where(eq(tableSessions.id, currentSession.id))
       .returning();
 
-    // Create payment record for the total amount
-    const transactionId = `TXN-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
-    
-    const newPayment = await db.insert(payments).values({
-      transactionNumber: transactionId,
-      customerName: currentSession.customerName,
-      customerPhone: currentSession.customerPhone,
-      totalAmount: totalCost.toFixed(2),
-      paymentMethods: JSON.stringify([{ type: 'cash', amount: totalCost.toFixed(2) }]),
-      staffId: currentSession.staffId,
-      status: 'pending',
-      tableAmount: tableCost.toFixed(2),
-      fnbAmount: fnbTotalCost.toFixed(2),
-      discountAmount: '0',
-      taxAmount: totalTaxAmount.toFixed(2),
-      // Legacy fields for compatibility
-      transactionId,
-      midtransOrderId: `ORDER-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
-      amount: totalCost.toFixed(2),
-      currency: 'IDR',
-      paymentMethod: 'cash',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }).returning();
-
-    const paymentId = newPayment[0].id;
-
-    // Link the table session to the payment
-    await db.update(tableSessions)
-      .set({ paymentId })
-      .where(eq(tableSessions.id, currentSession.id));
-
-    // Link all F&B orders for this table to the payment
-    if (fnbOrdersForTable.length > 0) {
-      await db.update(fnbOrders)
-        .set({ 
-          paymentId,
-          status: 'billed' // Update status to indicate it's now part of a bill
-        })
-        .where(and(
-          eq(fnbOrders.tableId, tableId),
-          eq(fnbOrders.status, 'pending')
-        ));
-    }
-
     // Update table status to available
     await db.update(tables)
       .set({ status: 'available', updatedAt: new Date() })
       .where(eq(tables.id, tableId));
 
+    // Return billing preview data (payment is NOT created yet — deferred to checkout confirmation)
     return NextResponse.json({
       session: endedSession[0],
-      payment: newPayment[0],
       billing: {
+        sessionId: currentSession.id,
+        tableId,
+        customerName: currentSession.customerName,
+        customerPhone: currentSession.customerPhone,
+        staffId: currentSession.staffId,
         actualDuration,
         originalDuration,
         calculatedDuration,
@@ -219,4 +178,4 @@ export async function POST(
   } catch (error) {
     return NextResponse.json({ error: 'Failed to end session' }, { status: 500 });
   }
-} 
+}

--- a/src/app/api/tables/[id]/start-session/route.ts
+++ b/src/app/api/tables/[id]/start-session/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { tables, tableSessions } from '@/schema/tables';
 import { pricingPackages } from '@/schema/pricing-packages';
+import { systemSettings } from '@/schema/settings';
 import { eq, and } from 'drizzle-orm';
 import { auth } from '@/lib/auth';
 
@@ -54,8 +55,15 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     // Determine duration type based on pricing package category
     const sessionDurationType = pricingPackage[0].category === 'per_minute' ? 'per_minute' : 'hourly';
 
-    // Get staff ID from session or use test default
-    const staffId = (session as any)?.staffId || (session?.user as any)?.staffId || 1;
+    // Get staff ID from session, then default staff setting, then fallback to 1
+    let staffId = (session as any)?.staffId || (session?.user as any)?.staffId;
+    if (!staffId) {
+      const defaultStaffSetting = await db.select().from(systemSettings)
+        .where(and(eq(systemSettings.key, 'default_staff_id'), eq(systemSettings.isActive, true)))
+        .limit(1);
+      const defaultId = defaultStaffSetting[0]?.value;
+      staffId = (defaultId && defaultId !== '0') ? parseInt(defaultId) : 1;
+    }
     
     // Start new session
     const newSession = await db.insert(tableSessions).values({

--- a/src/components/tables/DurationManagement.tsx
+++ b/src/components/tables/DurationManagement.tsx
@@ -1,14 +1,13 @@
 'use client';
 import React, { useState } from 'react';
 import { Button } from 'flowbite-react';
-import { IconClock, IconPlayerPause, IconEdit, IconDeviceFloppy, IconX } from '@tabler/icons-react';
+import { IconClock, IconEdit, IconDeviceFloppy, IconX } from '@tabler/icons-react';
 import { useTranslations } from 'next-intl';
 
 interface DurationManagementProps {
   sessionId: number;
   currentDurationType: 'hourly' | 'per_minute';
   elapsedMinutes: number;
-  onDurationTypeChange: (newType: 'hourly' | 'per_minute') => void;
   onDurationUpdate: (newDuration: number) => void;
   isUpdating?: boolean;
 }
@@ -17,7 +16,6 @@ const DurationManagement: React.FC<DurationManagementProps> = ({
   sessionId,
   currentDurationType,
   elapsedMinutes,
-  onDurationTypeChange,
   onDurationUpdate,
   isUpdating = false
 }) => {
@@ -37,11 +35,6 @@ const DurationManagement: React.FC<DurationManagementProps> = ({
     }
   };
 
-  const handleDurationTypeToggle = () => {
-    const newType = currentDurationType === 'hourly' ? 'per_minute' : 'hourly';
-    onDurationTypeChange(newType);
-  };
-
   return (
     <div className="bg-white dark:bg-darkgray border rounded-lg p-4 space-y-3">
       <div className="flex items-center justify-between">
@@ -51,16 +44,6 @@ const DurationManagement: React.FC<DurationManagementProps> = ({
             {tCommon('durationManagement')}
           </span>
         </div>
-
-        {/* Duration Type Toggle */}
-        <Button
-          size="xs"
-          color={currentDurationType === 'hourly' ? 'primary' : 'secondary'}
-          onClick={handleDurationTypeToggle}
-          disabled={isUpdating}
-        >
-          {currentDurationType === 'hourly' ? tCommon('changeToPerMinute') : tCommon('changeToHourly')}
-        </Button>
       </div>
 
       {/* Current Duration Display/Edit */}

--- a/src/components/tables/EnhancedBillingModal.tsx
+++ b/src/components/tables/EnhancedBillingModal.tsx
@@ -1,8 +1,16 @@
 'use client';
-import React, { useState, useEffect } from 'react';
-import { Modal, Button, Select, Label, TextInput } from 'flowbite-react';
-import { IconEdit, IconDeviceFloppy, IconX, IconClock, IconCurrencyDollar, IconLoader2 } from '@tabler/icons-react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Modal, Button, Label, TextInput } from 'flowbite-react';
+import { IconPrinter, IconCurrencyDollar, IconClock, IconLoader2 } from '@tabler/icons-react';
 import { useTranslations } from 'next-intl';
+
+interface TaxSettings {
+  enabled: boolean;
+  percentage: number;
+  name: string;
+  applyToTables: boolean;
+  applyToFnb: boolean;
+}
 
 interface BillingData {
   session: {
@@ -13,6 +21,11 @@ interface BillingData {
     endTime: string;
   };
   billing: {
+    sessionId: number;
+    tableId: number;
+    customerName: string;
+    customerPhone?: string;
+    staffId?: number;
     actualDuration: number;
     originalDuration: number;
     calculatedDuration: number;
@@ -22,11 +35,17 @@ interface BillingData {
       actualMinutes: number;
       billableHours?: number;
       billableMinutes?: number;
+      packageName?: string;
     };
     tableCost: number;
     fnbTotalCost: number;
+    subtotal: number;
+    tableTax: number;
+    fnbTax: number;
+    totalTaxAmount: number;
     totalCost: number;
     fnbOrders: any[];
+    taxSettings: TaxSettings;
   };
 }
 
@@ -37,6 +56,27 @@ interface EnhancedBillingModalProps {
   onConfirmPayment: (finalBillingData: BillingData) => void;
 }
 
+// Helper: convert minutes (decimal) to HH:mm:ss
+function minutesToHMS(totalMinutes: number): { hours: string; minutes: string; seconds: string } {
+  const totalSeconds = Math.round(totalMinutes * 60);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  return {
+    hours: String(h).padStart(2, '0'),
+    minutes: String(m).padStart(2, '0'),
+    seconds: String(s).padStart(2, '0'),
+  };
+}
+
+// Helper: convert HH:mm:ss to total minutes
+function hmsToMinutes(hours: string, minutes: string, seconds: string): number {
+  const h = parseInt(hours) || 0;
+  const m = parseInt(minutes) || 0;
+  const s = parseInt(seconds) || 0;
+  return h * 60 + m + s / 60;
+}
+
 const EnhancedBillingModal: React.FC<EnhancedBillingModalProps> = ({
   show,
   onClose,
@@ -44,22 +84,89 @@ const EnhancedBillingModal: React.FC<EnhancedBillingModalProps> = ({
   onConfirmPayment
 }) => {
   const tCommon = useTranslations('Common');
-  const [isEditingDuration, setIsEditingDuration] = useState(false);
-  const [editedDuration, setEditedDuration] = useState(0);
-  const [editedDurationType, setEditedDurationType] = useState<'hourly' | 'per_minute'>('hourly');
+  const tCheckout = useTranslations('AdminPage.checkout');
+  const [hours, setHours] = useState('00');
+  const [mins, setMins] = useState('00');
+  const [secs, setSecs] = useState('00');
   const [recalculatedBilling, setRecalculatedBilling] = useState<BillingData | null>(null);
   const [isRecalculating, setIsRecalculating] = useState(false);
   const [recalculationError, setRecalculationError] = useState<string | null>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (billingData) {
-      setEditedDuration(billingData.billing.actualDuration);
-      setEditedDurationType(billingData.billing.billingDetails.type);
+      const hms = minutesToHMS(billingData.billing.actualDuration);
+      setHours(hms.hours);
+      setMins(hms.minutes);
+      setSecs(hms.seconds);
       setRecalculatedBilling(null);
-      setIsEditingDuration(false);
       setRecalculationError(null);
     }
   }, [billingData]);
+
+  const handleRecalculate = useCallback(async (h: string, m: string, s: string) => {
+    if (!billingData) return;
+
+    const newMinutes = hmsToMinutes(h, m, s);
+    if (newMinutes <= 0) return;
+
+    // Skip if duration hasn't changed
+    if (Math.abs(newMinutes - billingData.billing.actualDuration) < 0.01 && !recalculatedBilling) return;
+
+    setIsRecalculating(true);
+    setRecalculationError(null);
+
+    try {
+      const response = await fetch(`/api/table-sessions/${billingData.session.id}/recalculate-billing`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ actualDuration: Math.round(newMinutes) }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setRecalculatedBilling({
+          session: billingData.session,
+          billing: {
+            ...billingData.billing,
+            ...data.billing,
+          }
+        });
+      } else {
+        const error = await response.json();
+        setRecalculationError(error.message || tCommon('failedToRecalculateBilling'));
+      }
+    } catch {
+      setRecalculationError(tCommon('errorRecalculatingBilling'));
+    } finally {
+      setIsRecalculating(false);
+    }
+  }, [billingData, recalculatedBilling, tCommon]);
+
+  // Debounced recalculation on time input change
+  const scheduleRecalculate = useCallback((h: string, m: string, s: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => handleRecalculate(h, m, s), 500);
+  }, [handleRecalculate]);
+
+  const handleTimeChange = (field: 'hours' | 'minutes' | 'seconds', value: string) => {
+    // Allow only numeric input, clamp values
+    const num = value.replace(/\D/g, '').slice(0, 2);
+    let newH = hours, newM = mins, newS = secs;
+    if (field === 'hours') { newH = num; setHours(num); }
+    if (field === 'minutes') { newM = num; setMins(num); }
+    if (field === 'seconds') { newS = num; setSecs(num); }
+    scheduleRecalculate(newH, newM, newS);
+  };
+
+  const handleConfirmPayment = () => {
+    const finalData = recalculatedBilling || billingData;
+    if (finalData) {
+      onConfirmPayment(finalData);
+    }
+  };
+
+  const currentBilling = recalculatedBilling || billingData;
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('id-ID', {
@@ -67,19 +174,6 @@ const EnhancedBillingModal: React.FC<EnhancedBillingModalProps> = ({
       currency: 'IDR',
       minimumFractionDigits: 0,
     }).format(amount);
-  };
-
-  const formatTime = (totalMinutes: number) => {
-    const currentDurationType = billingData?.billing.billingDetails.type;
-    if (currentDurationType === 'hourly') {
-      const hours = Math.floor(totalMinutes / 60);
-      const minutes = Math.round(totalMinutes % 60);
-      return `${hours} ${tCommon('hours')} ${minutes} ${tCommon('minutes')}`;
-    } else {
-      const minutes = Math.floor(totalMinutes);
-      const seconds = Math.round((totalMinutes - minutes) * 60);
-      return `${minutes} ${tCommon('min')} ${seconds} ${tCommon('sec')}`;
-    }
   };
 
   const formatDateTime = (dateString: string) => {
@@ -93,59 +187,10 @@ const EnhancedBillingModal: React.FC<EnhancedBillingModalProps> = ({
     });
   };
 
-  const handleRecalculateBilling = async () => {
-    if (!billingData) return;
-
-    setIsRecalculating(true);
-    setRecalculationError(null);
-
-    try {
-      const response = await fetch(`/api/table-sessions/${billingData.session.id}/recalculate-billing`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          actualDuration: editedDuration,
-          durationType: editedDurationType
-        }),
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setRecalculatedBilling({
-          session: billingData.session,
-          billing: data.billing
-        });
-        setIsEditingDuration(false);
-      } else {
-        const error = await response.json();
-        setRecalculationError(error.message || tCommon('failedToRecalculateBilling'));
-      }
-    } catch (error) {
-      setRecalculationError(tCommon('errorRecalculatingBilling'));
-    } finally {
-      setIsRecalculating(false);
-    }
-  };
-
-  const handleCancelEdit = () => {
-    if (billingData) {
-      setEditedDuration(billingData.billing.actualDuration);
-      setEditedDurationType(billingData.billing.billingDetails.type);
-    }
-    setIsEditingDuration(false);
-    setRecalculationError(null);
-  };
-
-  const handleConfirmPayment = () => {
-    const finalData = recalculatedBilling || billingData;
-    if (finalData) {
-      onConfirmPayment(finalData);
-    }
-  };
-
-  const currentBilling = recalculatedBilling || billingData;
-
   if (!billingData) return null;
+
+  const taxSettings = currentBilling?.billing.taxSettings;
+  const showTax = taxSettings?.enabled && (currentBilling?.billing.totalTaxAmount || 0) > 0;
 
   return (
     <Modal show={show} onClose={onClose} size="lg">
@@ -181,111 +226,74 @@ const EnhancedBillingModal: React.FC<EnhancedBillingModalProps> = ({
                   {formatDateTime(billingData.session.endTime)}
                 </span>
               </div>
+              <div>
+                <span className="text-bodytext">{tCommon('billingType')}:</span>
+                <span className="ml-2 font-medium text-dark dark:text-white">
+                  {currentBilling?.billing.billingDetails.type === 'hourly' ? tCommon('hourlyRate') : tCommon('perMinuteRate')}
+                  {currentBilling?.billing.billingDetails.packageName && (
+                    <span className="text-xs text-bodytext ml-1">({currentBilling.billing.billingDetails.packageName})</span>
+                  )}
+                </span>
+              </div>
             </div>
           </div>
 
-          {/* Duration Management */}
+          {/* Duration Input — HH:mm:ss */}
           <div className="border-b pb-4">
-            <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2 mb-3">
+              <IconClock className="w-5 h-5 text-primary" />
               <h3 className="text-lg font-semibold text-dark dark:text-white">
-                {tCommon('durationAndBillingType')}
+                {tCheckout('adjustDuration')}
               </h3>
-              {!isEditingDuration && (
-                <Button
-                  size="xs"
-                  color="secondary"
-                  onClick={() => setIsEditingDuration(true)}
-                >
-                  <IconEdit className="w-3 h-3 mr-1" />
-                  Edit Duration
-                </Button>
-              )}
+              {isRecalculating && <IconLoader2 className="w-4 h-4 animate-spin text-primary" />}
             </div>
 
-            {isEditingDuration ? (
-              <div className="space-y-4 bg-lightinfo p-4 rounded-lg">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="editDuration" value={tCommon('durationMinutes')} />
-                    <TextInput
-                      id="editDuration"
-                      type="number"
-                      value={editedDuration}
-                      onChange={(e) => setEditedDuration(parseInt(e.target.value) || 0)}
-                      min="1"
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="durationType" value={tCommon('billingType')} />
-                    <Select
-                      id="durationType"
-                      value={editedDurationType}
-                      onChange={(e) => setEditedDurationType(e.target.value as 'hourly' | 'per_minute')}
-                    >
-                      <option value="hourly">{tCommon('hourlyRate')}</option>
-                      <option value="per_minute">{tCommon('perMinuteRate')}</option>
-                    </Select>
-                  </div>
-                </div>
-
-                <div className="flex gap-2">
-                  <Button
-                    size="xs"
-                    color="primary"
-                    onClick={handleRecalculateBilling}
-                    disabled={isRecalculating}
-                  >
-                    {isRecalculating ? (
-                      <>
-                        <IconLoader2 className="w-3 h-3 mr-1 animate-spin" />
-                        Recalculating...
-                      </>
-                    ) : (
-                      <>
-                        <IconDeviceFloppy className="w-3 h-3 mr-1" />
-                        Recalculate
-                      </>
-                    )}
-                  </Button>
-                  <Button
-                    size="xs"
-                    color="secondary"
-                    onClick={handleCancelEdit}
-                    disabled={isRecalculating}
-                  >
-                    <IconX className="w-3 h-3 mr-1" />
-                    Cancel
-                  </Button>
-                </div>
-
-                {recalculationError && (
-                  <div className="text-error text-sm">
-                    {recalculationError}
-                  </div>
-                )}
+            <div className="flex items-center gap-2">
+              <div className="flex-1">
+                <Label htmlFor="durationHours" className="text-xs text-bodytext">{tCheckout('hours')}</Label>
+                <TextInput
+                  id="durationHours"
+                  value={hours}
+                  onChange={(e) => handleTimeChange('hours', e.target.value)}
+                  className="text-center font-mono text-lg"
+                  sizing="lg"
+                />
               </div>
-            ) : (
-              <div className="grid grid-cols-3 gap-4 text-sm">
-                <div>
-                  <span className="text-bodytext">Duration:</span>
-                  <div className="font-medium text-dark dark:text-white">
-                    {formatTime(currentBilling?.billing.actualDuration || 0)}
-                  </div>
-                </div>
-                <div>
-                  <span className="text-bodytext">{tCommon('billingType')}:</span>
-                  <div className="font-medium text-dark dark:text-white">
-                    {currentBilling?.billing.billingDetails.type === 'hourly' ? tCommon('hourlyRate') : tCommon('perMinuteRate')}
-                  </div>
-                </div>
+              <span className="text-2xl font-bold text-dark dark:text-white mt-4">:</span>
+              <div className="flex-1">
+                <Label htmlFor="durationMins" className="text-xs text-bodytext">{tCheckout('minutes')}</Label>
+                <TextInput
+                  id="durationMins"
+                  value={mins}
+                  onChange={(e) => handleTimeChange('minutes', e.target.value)}
+                  className="text-center font-mono text-lg"
+                  sizing="lg"
+                />
+              </div>
+              <span className="text-2xl font-bold text-dark dark:text-white mt-4">:</span>
+              <div className="flex-1">
+                <Label htmlFor="durationSecs" className="text-xs text-bodytext">{tCheckout('seconds')}</Label>
+                <TextInput
+                  id="durationSecs"
+                  value={secs}
+                  onChange={(e) => handleTimeChange('seconds', e.target.value)}
+                  className="text-center font-mono text-lg"
+                  sizing="lg"
+                />
+              </div>
+            </div>
+
+            {recalculatedBilling && (
+              <div className="mt-3 p-2 bg-lightsuccess rounded-lg">
+                <p className="text-success text-sm font-medium">
+                  ✓ Billing recalculated
+                </p>
               </div>
             )}
 
-            {recalculatedBilling && (
-              <div className="mt-3 p-3 bg-lightsuccess rounded-lg">
-                <p className="text-success text-sm font-medium">
-                  ✓ Billing has been recalculated with new duration and billing type
-                </p>
+            {recalculationError && (
+              <div className="mt-3 text-error text-sm">
+                {recalculationError}
               </div>
             )}
           </div>
@@ -320,6 +328,36 @@ const EnhancedBillingModal: React.FC<EnhancedBillingModalProps> = ({
                   {formatCurrency(currentBilling?.billing.fnbTotalCost || 0)}
                 </span>
               </div>
+
+              {/* Tax Breakdown */}
+              {showTax && (
+                <>
+                  <div className="border-t pt-2 mt-2">
+                    <div className="flex justify-between text-xs text-bodytext mb-1">
+                      <span>{tCheckout('taxBreakdown')} ({taxSettings?.name} {taxSettings?.percentage}%)</span>
+                    </div>
+                    {(currentBilling?.billing.tableTax || 0) > 0 && (
+                      <div className="flex justify-between text-xs text-bodytext">
+                        <span>  {tCheckout('tableTax')}:</span>
+                        <span>{formatCurrency(currentBilling?.billing.tableTax || 0)}</span>
+                      </div>
+                    )}
+                    {(currentBilling?.billing.fnbTax || 0) > 0 && (
+                      <div className="flex justify-between text-xs text-bodytext">
+                        <span>  {tCheckout('fnbTax')}:</span>
+                        <span>{formatCurrency(currentBilling?.billing.fnbTax || 0)}</span>
+                      </div>
+                    )}
+                    <div className="flex justify-between">
+                      <span className="text-bodytext">{taxSettings?.name}:</span>
+                      <span className="font-medium text-dark dark:text-white">
+                        {formatCurrency(currentBilling?.billing.totalTaxAmount || 0)}
+                      </span>
+                    </div>
+                  </div>
+                </>
+              )}
+
               <div className="flex justify-between text-lg font-semibold border-t pt-2">
                 <span className="text-dark dark:text-white">Total Cost:</span>
                 <span className="text-primary">
@@ -348,16 +386,16 @@ const EnhancedBillingModal: React.FC<EnhancedBillingModalProps> = ({
         </div>
       </Modal.Body>
       <Modal.Footer>
-        <Button 
-          color="primary" 
+        <Button
+          color="primary"
           onClick={handleConfirmPayment}
           disabled={isRecalculating}
         >
-          <IconCurrencyDollar className="w-4 h-4 mr-2" />
-          Confirm & Process Payment
+          <IconPrinter className="w-4 h-4 mr-2" />
+          {tCheckout('printAndSave')}
         </Button>
-        <Button 
-          color="secondary" 
+        <Button
+          color="secondary"
           onClick={onClose}
           disabled={isRecalculating}
         >

--- a/src/components/tables/EnhancedBillingModal.tsx
+++ b/src/components/tables/EnhancedBillingModal.tsx
@@ -371,13 +371,25 @@ const EnhancedBillingModal: React.FC<EnhancedBillingModalProps> = ({
           {currentBilling?.billing.fnbOrders && currentBilling.billing.fnbOrders.length > 0 && (
             <div>
               <h3 className="text-lg font-semibold text-dark dark:text-white mb-3">
-                F&B Orders ({currentBilling?.billing.fnbOrders?.length})
+                F&B Orders
               </h3>
-              <div className="max-h-32 overflow-y-auto space-y-2">
-                {currentBilling?.billing.fnbOrders?.map((order: any, index: number) => (
-                  <div key={index} className="flex justify-between text-sm p-2 bg-lightgray rounded">
-                    <span>{order.orderNumber}</span>
-                    <span className="font-medium">{formatCurrency(parseFloat(order.total))}</span>
+              <div className="max-h-40 overflow-y-auto space-y-1">
+                {currentBilling?.billing.fnbOrders?.map((order: any, orderIndex: number) => (
+                  <div key={orderIndex}>
+                    {order.items && order.items.length > 0
+                      ? order.items.map((item: any, itemIndex: number) => (
+                          <div key={itemIndex} className="flex justify-between text-sm p-2 bg-lightgray rounded">
+                            <span>{item.quantity}x {item.itemName || 'Item'}</span>
+                            <span className="font-medium">{formatCurrency(parseFloat(item.subtotal))}</span>
+                          </div>
+                        ))
+                      : (
+                          <div className="flex justify-between text-sm p-2 bg-lightgray rounded">
+                            <span>{order.orderNumber}</span>
+                            <span className="font-medium">{formatCurrency(parseFloat(order.total))}</span>
+                          </div>
+                        )
+                    }
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
Implements 8 client feedback items from the venue owner discussion:

- **Table sorting**: Natural numeric sort by name (Table 1, 2, 10 — not 1, 10, 2)
- **Receipt store info**: Store name, address, phone, notes pulled from new admin settings
- **Tax bug fix**: `recalculate-billing` now calculates tax correctly using package rates
- **Stop session confirmation**: Modal before stop, auto-end replaced with notification only
- **Billing type locked**: Removed ability to switch hourly↔per-minute on active sessions
- **HH:mm:ss duration editing**: Checkout modal uses `02:30:00` format, auto-recalculates price
- **Default staff setting**: Admin can set default staff, auto-populates F&B dropdown
- **Simplified checkout**: Payment deferred until admin confirms duration + prints receipt

## Key Architecture Change
The `end-session` API no longer creates payment records. It marks the session as completed and returns a billing preview. Payment is only created when the admin clicks "Print & Save" in the billing modal, via `POST /api/payments`.

## Files Changed (12)
- `messages/en.json`, `messages/id.json` — new translation keys
- `admin/page.tsx` — store settings + default staff cards
- `dashboard/page.tsx`, `tables/page.tsx` — natural sort, stop confirmation, checkout flow
- `transactions/page.tsx` — dynamic store info on receipt
- `payments/route.ts` — FnB order linking on checkout
- `recalculate-billing/route.ts` — tax fix + package rate lookup
- `end-session/route.ts` — deferred payment (billing preview only)
- `start-session/route.ts` — default staff from settings
- `DurationManagement.tsx` — removed billing type toggle
- `EnhancedBillingModal.tsx` — HH:mm:ss input, tax breakdown, Print & Save

## Test plan

https://github.com/user-attachments/assets/5d91a2d6-3f78-4085-8173-465971513f2a



- [x] Table sorting: Tables display sorted by number (1, 2, 10 not 1, 10, 2) on tables + dashboard
<img width="1422" height="623" alt="image" src="https://github.com/user-attachments/assets/93088ee6-6b45-4d7d-98df-b82b05b37d2a" />

- [x] Store settings: Fill in admin → print receipt → verify store info appears
- [x] Default staff: Set in admin → F&B dropdown pre-filled on tables page
<img width="997" height="863" alt="image" src="https://github.com/user-attachments/assets/f73609f1-b9ab-4a89-8a1d-7b171431f855" />
<img width="1002" height="665" alt="image" src="https://github.com/user-attachments/assets/e5bacbc2-891f-41f1-ae03-1e0386f82fc4" />


- [x] Stop confirmation: Click stop → modal appears → Cancel works, Confirm stops session
<img width="575" height="827" alt="image" src="https://github.com/user-attachments/assets/00e08d6d-ec97-40a9-bbcc-92e6c37ebb6a" />

- [x] Timer expiry: Planned session expires → notification shown, NO auto-stop
- [x] Billing type lock: No toggle on active session, no dropdown in checkout modal
- [x] Duration editing: HH:mm:ss input in checkout → change → price auto-recalculates with tax
- [x] Tax recalculation: Enable tax → stop session → tax lines in breakdown → adjust duration → tax updates
- [x] Full flow: Start → F&B → Stop → Confirm → Adjust duration → Print & Save → receipt prints → payment created
- [x] Deferred payment: Close billing modal without saving → no orphaned payment in transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)