### PR TITLE
Fix Tauri AppImage bundling on Ubuntu CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPIMAGE_EXTRACT_AND_RUN: 1
+          NO_STRIP: true
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Chalkboard ${{ github.ref_name }}'


### PR DESCRIPTION
## Summary
- v1.1.0 release failed on Ubuntu: `failed to run linuxdeploy` during AppImage bundling
- `linuxdeploy` is itself an AppImage needing FUSE to self-mount, but Ubuntu 22.04 runners only ship `libfuse3` — so it can't run
- Set `APPIMAGE_EXTRACT_AND_RUN=1` so helper AppImages extract instead of mounting
- Set `NO_STRIP=true` to fix the `__TAURI_BUNDLE_TYPE variable not found in binary` warning, which would otherwise break updater package-type detection

## Test plan
- [x] Merge to main
- [x] Delete the draft v1.1.0 release and re-tag v1.1.0
- [x] Verify the Ubuntu job completes and produces `.deb`, `.rpm`, and `.AppImage` artifacts
- [x] Confirm macOS and Windows builds still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release configuration to improve the stability of desktop releases across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kugie-app/chalkboard.id/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->