### PR TITLE
Drop AppImage from Tauri Linux bundle targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,6 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPIMAGE_EXTRACT_AND_RUN: 1
-          NO_STRIP: true
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Chalkboard ${{ github.ref_name }}'
@@ -172,7 +170,7 @@ jobs:
           echo "- **macOS (Apple Silicon):** \`.dmg\` (aarch64)" >> CHANGELOG.md
           echo "- **macOS (Intel):** \`.dmg\` (x86_64)" >> CHANGELOG.md
           echo "- **Windows:** \`.msi\` or \`.exe\` (NSIS)" >> CHANGELOG.md
-          echo "- **Linux:** \`.deb\`, \`.AppImage\`, or \`.rpm\`" >> CHANGELOG.md
+          echo "- **Linux:** \`.deb\` or \`.rpm\`" >> CHANGELOG.md
 
       - name: Update release from draft to published
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Native desktop application powered by [Tauri v2](https://v2.tauri.app/) with an 
 | **macOS (Apple Silicon)** | `.dmg` |
 | **macOS (Intel)** | `.dmg` |
 | **Windows** | `.msi` or `.exe` (NSIS) |
-| **Linux** | `.deb`, `.AppImage`, `.rpm` |
+| **Linux** | `.deb` or `.rpm` |
 
 1. Download the installer for your platform from the latest release
 2. Install and launch — the embedded PGlite database is set up automatically

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "rpm", "app", "dmg", "nsis", "msi"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary
- v1.1.0 release keeps failing on the Ubuntu 22.04 job at the AppImage bundling step (`failed to run linuxdeploy`)
- PR #19 fixed the FUSE-mount cause, but linuxdeploy now runs for ~18s and dies for an unknown reason — Tauri's CLI swallows linuxdeploy's stderr
- No `tauri-plugin-updater` is wired up, so AppImage isn't part of any runtime auto-update flow — it's pure distribution surface
- `.deb` + `.rpm` already bundle successfully and cover the major Linux families (Debian/Ubuntu, Fedora/RHEL)
- Switching `bundle.targets` from `"all"` to an explicit allowlist excluding `appimage` unblocks the release without affecting macOS/Windows artifacts

## Changes
- `src-tauri/tauri.conf.json`: `bundle.targets` → `["deb", "rpm", "app", "dmg", "nsis", "msi"]`
- `.github/workflows/release.yml`: removed now-unused `APPIMAGE_EXTRACT_AND_RUN` and `NO_STRIP` env vars; updated changelog text to drop `.AppImage`
- `README.md`: Linux installer row no longer lists `.AppImage`

## Test plan
- [ ] Merge to main
- [ ] Re-tag v1.1.0 (the draft release is still untouched)
- [ ] Verify `build-tauri (ubuntu-22.04)` completes with `.deb` + `.rpm` only — no AppImage stage
- [ ] Verify macOS x86_64 + aarch64 `.dmg` artifacts still produced
- [ ] Verify Windows `.msi` and NSIS `.exe` artifacts still produced
- [ ] Confirm no `.AppImage` appears in the published release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)