### PR TITLE
Bump README version header to v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🎱 Chalkboard.id v1.0.3
+# 🎱 Chalkboard.id v1.1.0
 
 A comprehensive billiard hall management system built with Next.js 15, React 19, and TypeScript. Manage table sessions, F&B orders, payments, staff, and analytics with ease.
 


### PR DESCRIPTION
## Summary
- Updates the README title from \`Chalkboard.id v1.0.3\` to \`Chalkboard.id v1.1.0\` to reflect the upcoming release
- Also gives main a fresh commit SHA to tag from — earlier tag-dance for v1.1.0 left GitHub Actions in a state where additional push-to-tag events at the old SHA stopped registering Release workflow runs. Tagging a brand-new SHA sidesteps that

## Test plan
- [ ] Merge to main
- [ ] Tag v1.1.0 from the new main HEAD and push
- [ ] Verify the Release workflow registers a fresh run
- [ ] Verify Linux/macOS/Windows desktop artifacts (excl. AppImage) are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated application version to v1.1.0 in the README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kugie-app/chalkboard.id/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->